### PR TITLE
modify buffer parameters

### DIFF
--- a/spectral.go
+++ b/spectral.go
@@ -31,7 +31,7 @@ type FilterBank struct {
 func NewFilterBank(filters uint, win_s uint) *FilterBank {
 	return  &FilterBank {
 		o: C.new_aubio_filterbank(C.uint_t(filters), C.uint_t(win_s)),
-		buf: NewSimpleBuffer(win_s),
+		buf: NewSimpleBuffer(filters),
 	}
 }
 
@@ -69,7 +69,7 @@ func NewPhaseVoc(bufSize, fftLen uint) (*PhaseVoc, error) {
 	}
 	return &PhaseVoc{
 		o: pvoc,
-		grain: NewComplexBuffer(fftLen)}, nil
+		grain: NewComplexBuffer(bufSize)}, nil
 }
 
 func (pv *PhaseVoc) Free() {


### PR DESCRIPTION
1. NewFilterBank方法中NewSimpleBuffer参数与filters大小应相同，如果参数为win_s，则会导致结果有大量的0值存在。
2. NewPhaseVoc方法中NewComplexBuffer参数应该为win_s，win_z与bufSize相等，此处应修改为bufSize，建议楼主把参数名与c语言的参数名相对应。